### PR TITLE
fix: update cf api format

### DIFF
--- a/src/api/cloudflare/api.rs
+++ b/src/api/cloudflare/api.rs
@@ -65,7 +65,6 @@ pub mod response {
         pub proxiable: bool,
         pub tags: Vec<String>,
         pub ttl: u32,
-        pub zone_name: String,
     }
 
     #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Cloudflare has removed the `zone_name` field from their api, and this PR fixes the 'missing' field error when describing the record.